### PR TITLE
Fix no-root-node deprecation notice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,10 @@ matrix:
       env: SYMFONY_VERSION='~3.4.0'
     - php: 7.2
       env: SYMFONY_VERSION='~4.0'
+    - php: 7.3
+      env: SYMFONY_VERSION='~3.4.0'
+    - php: 7.3
+      env: SYMFONY_VERSION='~4.0'
 
 before_script:
   - phpenv config-add travis.php.ini

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -15,9 +15,11 @@ class Configuration implements ConfigurationInterface
     /** {@inheritdoc} */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode    = $treeBuilder->root('basster_legacy_bridge');
-
+        $treeBuilder = new TreeBuilder('basster_legacy_bridge');
+        $rootNode = method_exists($treeBuilder, 'getRootNode') 
+            ? $treeBuilder->getRootNode() 
+            : $treeBuilder->root('monolog');
+        
         $rootNode
           ->children()
           ->scalarNode('legacy_path')

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,7 +18,7 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder('basster_legacy_bridge');
         $rootNode = method_exists($treeBuilder, 'getRootNode') 
             ? $treeBuilder->getRootNode() 
-            : $treeBuilder->root('monolog');
+            : $treeBuilder->root('basster_legacy_bridge');
         
         $rootNode
           ->children()

--- a/travis.php.ini
+++ b/travis.php.ini
@@ -1,1 +1,1 @@
-memory_limit = 1024M
+memory_limit = -1


### PR DESCRIPTION
This PR is intended to fix a deprecation notice:
> A tree builder without a root node is deprecated